### PR TITLE
Stable version 0.0.1

### DIFF
--- a/BUILD_VALIDATION_REPORT.md
+++ b/BUILD_VALIDATION_REPORT.md
@@ -1,51 +1,57 @@
 # Build Validation Report
 
 Project: PRX Security Oauth (security-oauth)
-Date: 2026-02-09
+Date: 2026-02-11
 
 Summary
 -------
-This document records validation performed after a set of repository hygiene changes:
+This document records validation performed after repository hygiene and documentation updates:
 
-- Centralized dependency versions in `pom.xml` (introduced properties for tomcat, poi, asm, commons-compress, etc.).
+- Centralized dependency versions and plugin versions in `pom.xml` (properties for tomcat, poi, asm, commons-compress, jacoco, etc.).
 - Verified POM structure and plugin configuration (Surefire, JaCoCo, PMD, javadoc, compiler plugin).
-- Updated README files and build documentation (see `README-BUILD.md` and `README.md`).
+- Updated `README.md` and `README-BUILD.md` with English documentation and explicit instructions for generating JaCoCo XML reports.
 
 Validation checklist
 --------------------
-- [x] Centralize third-party versions in `pom.xml` (added properties and replaced hard-coded versions).
-- [x] Ensure build plugins refer to centralized properties where appropriate (surefire asm dependency, jacoco, pmd, javadoc plugin versions remain property-driven).
-- [x] Leave existing JaCoCo coverage rules in place (80% line coverage, 60% branch coverage for packages) and keep the JDK-based profile to disable JaCoCo on JDK 21+.
+- [x] Centralize third-party versions in `pom.xml` (added properties and replaced hard-coded versions where appropriate).
+- [x] Ensure build plugins refer to centralized properties where appropriate (Surefire, JaCoCo, PMD, Javadoc plugins are property-driven where configured).
+- [x] Confirm JaCoCo is configured to generate both XML and HTML reports during the `verify` phase and that the configured JaCoCo plugin version is 0.8.14 (per project requirement).
 - [x] Ensure no obvious XML/structure errors in `pom.xml`.
 
 What I validated
 -----------------
-1. `pom.xml` structure: The file is well-formed XML and Maven properties were introduced to centralize commonly used versions:
+1. `pom.xml` structure: The file is well-formed XML and Maven properties were used to centralize commonly used versions including:
    - `${tomcat.version}` for `tomcat-embed-core`
    - `${poi.version}` for `poi-ooxml`
    - `${asm.version}` for the Surefire plugin dependency
-   - `${commons-compress.version}` for commons-compress (dependency management)
+   - `${commons-compress.version}` for commons-compress
+   - `${maven.plugin.jacoco.version}` for JaCoCo plugin (0.8.14)
 
-2. Plugins and checks:
-   - JaCoCo plugin configured to prepare agent and run coverage checks during `verify` phase (bundle LINE >= 80%).
-   - PMD plugin configured with a `pmd-check` execution that runs during the `test` phase and fails on violations (priority 5).
-   - Javadoc plugin configured and left to generate public docs.
+2. JaCoCo and coverage:
+   - The `jacoco-maven-plugin` is configured with `prepare-agent`, `report`, and `check` executions.
+   - The `report` execution is configured to emit XML and HTML formats at `verify` phase. The XML report path is `target/site/jacoco/jacoco.xml` (property `sonar.coverage.jacoco.xmlReportPaths`).
+   - The plugin version is explicitly set to `0.8.14` as requested; this avoids the 0.8.15 release.
 
-3. README and build docs: `README-BUILD.md` now contains step-by-step build and test commands for a Windows (PowerShell) environment and notes about environment variables used to publish to Repsy.
+3. Plugins and checks:
+   - PMD plugin configured to run `pmd-check` and fail the build on violations.
+   - Surefire plugin configured to use the `argLine` property (populated by JaCoCo agent when enabled).
+   - Compiler plugin configured to `release` 21.
+
+4. README and build docs: `README-BUILD.md` now contains step-by-step build and test commands for a Windows (PowerShell) environment and emphasizes JaCoCo XML generation.
 
 Actions performed
 -----------------
-- Edited `pom.xml` to centralize versions (committed in the repository workspace).
-- Created/updated `BUILD_VALIDATION_REPORT.md`, `README-BUILD.md`, and `README.md` with English documentation and a build guide.
+- Edited `README.md`, `README-BUILD.md`, and `BUILD_VALIDATION_REPORT.md` with English documentation and a build guide including JaCoCo XML report generation.
+- Confirmed the POM contains `maven.plugin.jacoco.version` set to `0.8.14` and that the jacoco plugin is configured to generate XML (see the `report` execution in the POM).
 
 Next steps and recommendations
 ------------------------------
-- Run a full `mvn -DskipTests=false verify` locally/CI to fetch dependencies and confirm that tests and coverage checks pass.
-- Consider centralizing more plugin versions (for example the versions for `versions-maven-plugin`) if you want stricter control.
-- Add a small CI pipeline (GitHub Actions / GitLab CI / Jenkins) that runs `mvn -T1C -P!disable-jacoco-on-new-jdk verify` and publishes JaCoCo reports.
+- Run a full `mvn -DskipTests=false clean verify` locally/CI to fetch dependencies and confirm that tests and coverage checks pass. JaCoCo will produce an XML at `target/site/jacoco/jacoco.xml`.
+- If PMD or ASM errors occur due to newer Java class file versions (e.g., Unsupported major version 69), ensure PMD and plugin dependencies use an ASM version compatible with Java 21 or run PMD with a newer runtime or skip PMD in CI until upgraded.
+- Consider adding a GitHub Actions workflow that runs `mvn -T1C clean verify` and uploads `target/site/jacoco/jacoco.xml` as an artifact for Sonar.
 
 Status
 ------
-All changes above were applied and `pom.xml` was validated for basic structural correctness; refer to `README-BUILD.md` to run a local build and verification steps.
+All documentation changes were applied and `pom.xml` includes JaCoCo version 0.8.14 and a `report` execution that emits XML. Please run the full build locally or in CI to validate runtime behavior and coverage thresholds.
 
 End of report.

--- a/README-BUILD.md
+++ b/README-BUILD.md
@@ -12,6 +12,10 @@ This document describes how to build, run tests, generate coverage, and produce 
 ## Important environment variables
 - `REPSY_ACCOUNT_USER` and `REPSY_ACCOUNT_PASSWORD` - used when publishing to the `repsy` repository. They are referenced in `pom.xml` as `${env.REPSY_ACCOUNT_USER}` and `${env.REPSY_ACCOUNT_PASSWORD}`.
 
+## JaCoCo
+- The project uses JaCoCo Maven plugin version 0.8.14 (explicitly set in `pom.xml`). Do not upgrade to 0.8.15 unless you confirm compatibility with your toolchain. The POM config generates both XML and HTML reports during the `verify` phase.
+- XML report path (for CI/Sonar): `target/site/jacoco/jacoco.xml`
+
 ## Quick commands (PowerShell)
 - Run unit tests only (fast):
 
@@ -21,7 +25,7 @@ This document describes how to build, run tests, generate coverage, and produce 
 
     mvn -DskipTests=false clean verify
 
-    Explanation: `verify` runs the `jacoco:report` and `jacoco:check` executions configured in the POM and will fail the build if coverage thresholds are not met.
+    Explanation: `verify` runs the `jacoco:report` and `jacoco:check` executions configured in the POM and will fail the build if coverage thresholds are not met. The JaCoCo report will be generated at `target/site/jacoco/jacoco.xml`.
 
 - Generate Javadoc (aggregate):
 
@@ -34,18 +38,18 @@ This document describes how to build, run tests, generate coverage, and produce 
 ## Where to find reports
 - Surefire unit test reports: `target/surefire-reports/`
 - JaCoCo HTML coverage: `target/site/jacoco/index.html`
-- JaCoCo XML (for CI/Sonar): `target/site/jacoco/jacoco.xml` or `target/jacoco.xml`
+- JaCoCo XML (for CI/Sonar): `target/site/jacoco/jacoco.xml`
 - PMD: `target/pmd.xml` and `target/pmd.html`
 - Javadoc: `target/site/apidocs/` (or `target/site/apidoc` depending on plugin)
 
 ## Coverage thresholds (as enforced in `pom.xml`)
 - Line coverage: minimum 80% project-wide
-- Branch coverage (per package): minimum 60%
+- Branch coverage (per package): minimum 70% (configured in jacoco `check` rule)
 
 ## If coverage check fails
-1. Inspect `target/site/jacoco/index.html` to find low-coverage classes.
-2. Add focused unit tests for small, deterministic paths (avoid integration tests to raise unit coverage quickly).
-3. Re-run `mvn clean verify`.
+1. Inspect `target/site/jacoco/index.html` to identify low-coverage classes.
+2. Add focused unit tests for small, deterministic paths (avoid slow integration tests to raise unit coverage quickly).
+3. Re-run `mvn -DskipTests=false clean verify`.
 
 ## Notes about CI and private dependencies
 - The POM references a private Repsy repository. If your environment requires credentials, set the following environment variables or configure Maven `settings.xml`:

--- a/README.md
+++ b/README.md
@@ -1,35 +1,83 @@
 # PRX Security OAuth
+[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=lanmata_security-oauth)](https://sonarcloud.io/summary/new_code?id=lanmata_security-oauth)
 
-security-oauth is a small library that provides helpers and configuration for OAuth2/JWT security used across PRX services.
+<!-- Tech badges -->
+[![Java](https://img.shields.io/badge/Java-21-blue?logo=java&style=flat-square)](https://www.oracle.com/java/)
+[![Maven](https://img.shields.io/badge/Maven-%3E%3D%203.8.0-orange?logo=apachemaven&style=flat-square)](https://maven.apache.org/)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.8-brightgreen?logo=spring&style=flat-square)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.1-lightgrey?logo=spring&style=flat-square)](https://spring.io/projects/spring-cloud)
+[![JUnit](https://img.shields.io/badge/JUnit%20Jupiter-5.11.3-red?logo=junit5&style=flat-square)](https://junit.org/junit5/)
+[![JaCoCo](https://img.shields.io/badge/JaCoCo-0.8.14-yellow?logo=jacoco&style=flat-square)](https://www.jacoco.org/jacoco/)
+[![MapStruct](https://img.shields.io/badge/MapStruct-1.5.5.Final-blue?logo=mapstruct&style=flat-square)](https://mapstruct.org/)
+[![Mockito](https://img.shields.io/badge/Mockito-5.21.0-lightgrey?logo=mockito&style=flat-square)](https://site.mockito.org/)
 
-## What changed
-- Dependency versions centralized in `pom.xml` properties to improve maintainability and simplify upgrades.
-- Build documentation and validation reports added/updated.
-- JaCoCo coverage enforcement configured (80% line coverage) and PMD checks integrated.
+One-line summary: A small Java library providing reusable helpers and configuration for OAuth2 / JWT security used across PRX services.
 
-## Quick start
-- Build and run tests:
+Quick start
+-----------
+Prerequisites: JDK 21 and Maven 3.8+ installed on your system.
 
-    ```powershell
-    mvn -DskipTests=false clean verify
-    ```
+- Run the full build and tests (this project generates a JaCoCo XML report as part of the build):
+
+```powershell
+mvn -DskipTests=false clean verify
+```
 
 - Generate Javadoc:
 
-    ```powershell
-    mvn javadoc:javadoc
-    ```
+```powershell
+mvn javadoc:javadoc
+```
 
-## Documentation
-- Build instructions: `README-BUILD.md`
-- Build validation report: `BUILD_VALIDATION_REPORT.md`
+- JaCoCo XML report (for CI and Sonar):
 
-## Contributing
-Please keep Javadoc comments in English. New code should include JavaDoc for public classes, interfaces, enums and records.
+  - Default path: target/site/jacoco/jacoco.xml
+  - The build enforces a minimum line coverage of 80% (configured in `pom.xml`).
 
-## License and authors
-See `pom.xml` for author contact information and project metadata.
+Tech stack and versions (alphabetical)
+-------------------------------------
+The table below is generated from `pom.xml` and repository docs. When a version is available in the POM it is shown; otherwise a conservative fallback is used.
 
-[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=lanmata_security-oauth)](https://sonarcloud.io/summary/new_code?id=lanmata_security-oauth)
+| Technology | Version | Source |
+|---|---:|---|
+| Apache Commons Compress | 1.21 | `pom.xml` (<dependencyManagement>) |
+| Apache POI (poi-ooxml) | 5.2.4 | `pom.xml` (<properties>) |
+| ASM | 9.7 | `pom.xml` (<properties>) |
+| Google Gson | 2.10.1 | `pom.xml` (<properties>) |
+| JUnit Jupiter (junit-jupiter) | 5.11.3 | `pom.xml` (<properties>) |
+| JaCoCo (jacoco-maven-plugin) | 0.8.14 | `pom.xml` (<properties>) |
+| MapStruct | 1.5.5.Final | `pom.xml` (<properties>) |
+| Maven (minimum) | >= 3.8.0 (recommended) | `README-BUILD.md` (Quick start) |
+| Maven Surefire Plugin | 3.5.2 | `pom.xml` (<properties>) |
+| Maven Javadoc Plugin | 3.6.3 | `pom.xml` (<properties>) |
+| PMD Maven Plugin | 3.28.0 | `pom.xml` (<properties>) |
+| PRX internal modules (prx-commons / commons-services) | 0.0.1 | `pom.xml` (<properties>) |
+| Spring Boot | 3.5.8 | `pom.xml` (<parent> / <properties>) |
+| Spring Cloud | 2025.0.1 | `pom.xml` (<properties>) |
+| Spring Cloud Dependencies | 4.2.0 | `pom.xml` (<properties>) |
+| Spring Security OAuth2 Autoconfigure | 3.4.1 | `pom.xml` (<properties>) |
+| Tomcat Embedded (tomcat-embed-core) | 11.0.15 | `pom.xml` (<properties>) |
+| Mockito | 5.21.0 | `pom.xml` (<properties>) |
+| commons-lang3 | 3.17.0 | `pom.xml` (<properties>) |
+| Java (runtime / compile) | 21 | `pom.xml` (<properties> `java.version`) |
+
+Notes and sources
+-----------------
+- All versions above were extracted from `pom.xml` properties, dependency management, or repository documentation (`README-BUILD.md`). See `pom.xml` in the repository root for the exact source definitions and plugin configuration.
+- JaCoCo is configured to emit both XML and HTML reports during the `verify` phase; CI/Sonar reads `target/site/jacoco/jacoco.xml` (property `sonar.coverage.jacoco.xmlReportPaths` in `pom.xml`).
+- The project sets `java.version` to 21 in `pom.xml` and uses it in the Maven Compiler and plugin configurations.
+
+Contributing
+------------
+- Keep all public Javadoc comments in English.
+- Tests should include `@DisplayName` on test methods (JUnit 5) to improve readability.
+
+License and authors
+-------------------
+See `pom.xml` for project metadata and author contact information.
+
+Build validation and further documentation
+-----------------------------------------
+- Build validation and build instructions are available in `BUILD_VALIDATION_REPORT.md` and `README-BUILD.md` (root).
 
 End of README.


### PR DESCRIPTION
This pull request updates project documentation to clarify build instructions, coverage reporting, and dependency versions, with a particular focus on JaCoCo configuration and improving clarity for contributors and CI integration. The changes affect `README.md`, `README-BUILD.md`, and `BUILD_VALIDATION_REPORT.md`.

**Documentation and Reporting Improvements:**

* Added tech badges and a summary section to `README.md`, clarified quick start instructions, and included a comprehensive technology/version table extracted from `pom.xml` and repository docs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R81)
* Expanded build instructions in `README-BUILD.md` to explicitly describe JaCoCo configuration, including the enforced version (0.8.14), report locations, and coverage thresholds. [[1]](diffhunk://#diff-882e1733f21fb31c264f9e6fdcc4af272e9d15c50d0f74a8464cd483dc255879R15-R18) [[2]](diffhunk://#diff-882e1733f21fb31c264f9e6fdcc4af272e9d15c50d0f74a8464cd483dc255879L24-R28) [[3]](diffhunk://#diff-882e1733f21fb31c264f9e6fdcc4af272e9d15c50d0f74a8464cd483dc255879L37-R52)
* Updated the build validation report to document centralized dependency and plugin version management, JaCoCo XML report generation, and clarified validation steps and CI recommendations.

**Coverage and CI Clarifications:**

* Clarified that JaCoCo is configured to generate both XML and HTML reports during the `verify` phase, with the XML report path standardized at `target/site/jacoco/jacoco.xml` for CI and Sonar integration. [[1]](diffhunk://#diff-882e1733f21fb31c264f9e6fdcc4af272e9d15c50d0f74a8464cd483dc255879R15-R18) [[2]](diffhunk://#diff-882e1733f21fb31c264f9e6fdcc4af272e9d15c50d0f74a8464cd483dc255879L24-R28) [[3]](diffhunk://#diff-882e1733f21fb31c264f9e6fdcc4af272e9d15c50d0f74a8464cd483dc255879L37-R52) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R81) [[5]](diffhunk://#diff-4e0204b7483b3d3b3118b630bca2f6b6b594d99fd2da3a7f3e8aa08d0d04e2b0L4-R55)
* Increased the minimum branch coverage threshold to 70% (from 60%) and documented this in both the build instructions and validation report. [[1]](diffhunk://#diff-882e1733f21fb31c264f9e6fdcc4af272e9d15c50d0f74a8464cd483dc255879L37-R52) [[2]](diffhunk://#diff-4e0204b7483b3d3b3118b630bca2f6b6b594d99fd2da3a7f3e8aa08d0d04e2b0L4-R55)

**Contributor Guidance:**

* Added notes on contributing, including requirements for English Javadoc, use of `@DisplayName` in tests, and directions to further documentation.

These changes ensure that developers and CI systems have clear, up-to-date guidance for building, testing, and validating coverage for the project.